### PR TITLE
[FEAT] 계좌 잔액 조회 API 및 JWT 토큰 기반 결제 

### DIFF
--- a/backend/core-bank/src/main/java/com/heyoung/domain/payment/controller/AccountController.java
+++ b/backend/core-bank/src/main/java/com/heyoung/domain/payment/controller/AccountController.java
@@ -1,0 +1,29 @@
+package com.heyoung.domain.payment.controller;
+
+import com.heyoung.domain.payment.dto.AccountBalanceDto;
+import com.heyoung.domain.payment.service.AccountService;
+import com.heyoung.global.config.MemberId;
+import com.heyoung.global.exception.BaseResponse;
+import com.heyoung.global.exception.ResponseCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name="계좌 정보 API", description = "사용자 계좌 정보 조회를 담당합니다.")
+@RestController
+@RequestMapping("/accounts")
+@RequiredArgsConstructor
+public class AccountController {
+
+    private final AccountService accountService;
+
+    @Operation(summary="사용자 계좌 잔액 조회 API", description = "현재 사용자의 계좌 잔액을 실시간으로 조회합니다.")
+    @GetMapping("/balance")
+    public BaseResponse<AccountBalanceDto> getMyAccountBalance(@MemberId Long memberId) {
+        AccountBalanceDto accountBalance = accountService.getAccountBalance(memberId);
+        return BaseResponse.onSuccess(accountBalance, ResponseCode.OK);
+    }
+}

--- a/backend/core-bank/src/main/java/com/heyoung/domain/payment/controller/TransactionController.java
+++ b/backend/core-bank/src/main/java/com/heyoung/domain/payment/controller/TransactionController.java
@@ -1,6 +1,6 @@
 package com.heyoung.domain.payment.controller;
 
-import com.heyoung.domain.payment.dto.QrDataDto;
+import com.heyoung.domain.payment.dto.QrTokenDto;
 import com.heyoung.domain.payment.dto.TransactionRequestDto;
 import com.heyoung.domain.payment.dto.TransactionResponseDto;
 import com.heyoung.domain.payment.service.TransactionService;
@@ -22,9 +22,9 @@ public class TransactionController {
 
     @Operation(summary="결제 QR 화면 요청 API", description = "사용자가 '결제하기' 버튼을 누르면 호출됩니다.")
     @GetMapping("/qr-data")
-    public BaseResponse<QrDataDto> getQrData(@MemberId Long memberId) {
-        QrDataDto qrData = transactionService.generateQrData(memberId);
-        return BaseResponse.onSuccess(qrData, ResponseCode.OK);
+    public BaseResponse<QrTokenDto> getQrData(@MemberId Long memberId) {
+        QrTokenDto qrTokenDto = transactionService.generateQrData(memberId);
+        return BaseResponse.onSuccess(qrTokenDto, ResponseCode.OK);
     }
     @Operation(summary="결제 실행 API", description = "가맹점 POS기에서 QR 스캔 후 호출하는 API입니다.")
     @PostMapping("/execute")

--- a/backend/core-bank/src/main/java/com/heyoung/domain/payment/dto/AccountBalanceDto.java
+++ b/backend/core-bank/src/main/java/com/heyoung/domain/payment/dto/AccountBalanceDto.java
@@ -1,0 +1,13 @@
+package com.heyoung.domain.payment.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@Getter
+@AllArgsConstructor
+public class AccountBalanceDto {
+    private String accountNumber;
+    private BigDecimal balance;
+}

--- a/backend/core-bank/src/main/java/com/heyoung/domain/payment/dto/QrTokenDto.java
+++ b/backend/core-bank/src/main/java/com/heyoung/domain/payment/dto/QrTokenDto.java
@@ -7,7 +7,6 @@ import lombok.NoArgsConstructor;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
-public class QrDataDto {
-    private Long userId;
-    private String accountNumber;
+public class QrTokenDto {
+    private String qrToken;
 }

--- a/backend/core-bank/src/main/java/com/heyoung/domain/payment/dto/TransactionRequestDto.java
+++ b/backend/core-bank/src/main/java/com/heyoung/domain/payment/dto/TransactionRequestDto.java
@@ -6,8 +6,7 @@ import java.math.BigDecimal;
 
 @Getter
 public class TransactionRequestDto { // 가맹점 -> 서버 결제 요청 (QR 찍기)
-    private Long userId;
-    private String accountNumber; // 계좌번호
+    private String qrToken; // 사용자 qrToken
     private BigDecimal finalAmount; // 최종 결제 금액
     private BigDecimal originalAmount; // 할인 전 금액
     private String transactionSummary; // 출금 계좌 요약

--- a/backend/core-bank/src/main/java/com/heyoung/domain/payment/service/AccountService.java
+++ b/backend/core-bank/src/main/java/com/heyoung/domain/payment/service/AccountService.java
@@ -1,0 +1,34 @@
+package com.heyoung.domain.payment.service;
+
+import com.heyoung.domain.payment.dto.AccountBalanceDto;
+import com.heyoung.domain.payment.entity.Account;
+import com.heyoung.domain.payment.repository.AccountRepository;
+import com.heyoung.domain.user.entity.User;
+import com.heyoung.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+
+@Service
+@RequiredArgsConstructor
+public class AccountService {
+
+    private final UserRepository userRepository;
+    private final AccountRepository accountRepository;
+    private final ExternalBankApiService externalBankApiService;
+
+    @Transactional(readOnly = true)
+    public AccountBalanceDto getAccountBalance(Long memberId) {
+        User user = userRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자"));
+
+        Account account = accountRepository.findByUser(user)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 계좌"));
+
+        BigDecimal currentBalance = externalBankApiService.inquireBalance(account.getAccountNumber(), user.getId());
+
+        return new AccountBalanceDto(account.getAccountNumber(), currentBalance);
+    }
+}

--- a/backend/core-bank/src/main/java/com/heyoung/domain/payment/service/TransactionService.java
+++ b/backend/core-bank/src/main/java/com/heyoung/domain/payment/service/TransactionService.java
@@ -1,6 +1,7 @@
 package com.heyoung.domain.payment.service;
 
 import com.heyoung.domain.payment.dto.QrDataDto;
+import com.heyoung.domain.payment.dto.QrTokenDto;
 import com.heyoung.domain.payment.dto.TransactionRequestDto;
 import com.heyoung.domain.payment.dto.TransactionResponseDto;
 import com.heyoung.domain.payment.entity.Account;
@@ -38,19 +39,22 @@ public class TransactionService {
 
     // 사용자 qr 데이터
     @Transactional(readOnly = true)
-    public QrDataDto generateQrData(Long memberId) {
+    public QrTokenDto generateQrData(Long memberId) {
         User user = userRepository.findById(memberId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자"));
         Account account = accountRepository.findByUser(user)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 계좌"));
         String qrToken = jwtUtil.generateQrToken(user.getId(), account.getAccountNumber());
-        return new QrDataDto(qrToken);
+        return new QrTokenDto(qrToken);
     }
 
     // 사용자 잔액 기반 거래 가능 여부 파악 후 출금
     @Transactional
     public TransactionResponseDto executeTransaction(TransactionRequestDto requestDto) {
-        User user = userRepository.findById(requestDto.getUserId())
+        QrDataDto qrDataDto = jwtUtil.parseQrToken(requestDto.getQrToken());
+        Long userId = qrDataDto.getUserId();
+
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자"));
         Account account = accountRepository.findByUser(user)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 계좌"));

--- a/backend/core-bank/src/main/java/com/heyoung/global/config/JwtUtil.java
+++ b/backend/core-bank/src/main/java/com/heyoung/global/config/JwtUtil.java
@@ -1,5 +1,6 @@
 package com.heyoung.global.config;
 
+import com.heyoung.domain.payment.dto.QrDataDto;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
@@ -29,7 +30,7 @@ public class JwtUtil {
         claims.put("accountNumber", accountNumber);
 
         Date now = new Date();
-        Date expiryDate = new Date(now.getDate() + qrTokenExpirationMs);
+        Date expiryDate = new Date(now.getTime() + qrTokenExpirationMs);
 
         return Jwts.builder()
                 .setClaims(claims)
@@ -39,5 +40,16 @@ public class JwtUtil {
                 .compact();
     }
 
-    //
+    // 결제 실행 시 필요 - QR jwt 파싱하여 정보 추출
+    public QrDataDto parseQrToken(String token) {
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+
+        Long userId = claims.get("userId", Long.class);
+        String accountNumber = claims.get("accountNumber", String.class);
+        return new QrDataDto(userId, accountNumber);
+    }
 }


### PR DESCRIPTION
## 📌 관련 이슈

- closed: #38  #53 

## ✨ PR 세부 내용
* **`AccountBalanceDto` 신규 생성**
  - API 응답 시 계좌 번호(`accountNumber`)와 잔액(`balance`) 정보를 명확하게 전달하기 위한 DTO를 정의
  
* **`AccountService` 신규 생성**
  - 계좌 잔액 조회 관련 비즈니스 로직을 전담하는 서비스 추가 
  - 기존에 구현된 `ExternalBankApiService`의 `inquireBalance` 메소드를 재사용하여 외부 은행 API에 실시간 잔액을 요청하고, 해당 결과 반환
  
 * **`AccountController` 신규 생성**
    - `GET /accounts/balance` API 엔드포인트를 추가하여 잔액 조회 요청을 처리
