### PR TITLE
[FEAT] 알림 예약 및 알림 전송 기능 구현

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -50,3 +50,5 @@ core-bank/Dockerfile
 
 /docker-compose.yml
 /.dockerignore
+
+community/src/main/resources/heyoung-firebase-adminsdk.json

--- a/backend/community/build.gradle
+++ b/backend/community/build.gradle
@@ -28,6 +28,12 @@ dependencies {
     runtimeOnly 'org.postgresql:postgresql'
 //    testImplementation 'com.h2database:h2'
 
+    // 알림 예약을 위한 batch
+    implementation 'org.springframework.boot:spring-boot-starter-batch'
+
+    // 알림 전송을 위한 FCM 의존성 추가
+    implementation 'com.google.firebase:firebase-admin:9.2.0'   // FCM
+
     testImplementation platform('org.junit:junit-bom:5.10.0')
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/backend/community/src/main/java/com/heyoung/domain/benefit/repository/PartnershipRepository.java
+++ b/backend/community/src/main/java/com/heyoung/domain/benefit/repository/PartnershipRepository.java
@@ -1,8 +1,10 @@
 package com.heyoung.domain.benefit.repository;
 
+import com.heyoung.domain.benefit.entity.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
 import com.heyoung.domain.benefit.entity.Partnership;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -14,4 +16,40 @@ public interface PartnershipRepository extends JpaRepository<Partnership, Long> 
     // fetch join -> partnership과 university 함께 조회하는 jpql 쿼리(n+1 문제 해결)
     @Query("SELECT p FROM Partnership p JOIN FETCH p.university")
     List<Partnership> findAllWithUniversity();
+
+    @Query("""
+      select distinct p
+      from Partnership p
+      where p.status = com.heyoung.global.enums.PartnershipStatus.ACTIVE
+        and p.category in :cats
+        and exists (
+          select b.id
+          from PartnershipBranch b
+          where b.partnership = p
+            and b.status = com.heyoung.global.enums.PartnershipStatus.ACTIVE
+            and b.startDate <= :today and :today <= b.endDate
+        )
+        and not exists (
+          select nl2.id
+          from NotificationLog nl2
+          where nl2.userId = :userId
+            and nl2.occurredAt >= :cutoff
+            and nl2.notification.partnership = p
+        )
+      order by p.id desc
+    """)
+    List<Partnership> findActiveByCategoriesExcludeSent(
+            @Param("cats")  List<Category> cats,
+            @Param("today") java.time.LocalDate today,
+            @Param("userId") Long userId,
+            @Param("cutoff") java.time.Instant cutoff
+    );
+    /** 사용법.
+     * LocalDate today  = LocalDate.now(ZoneId.of("Asia/Seoul"));
+     * Instant cutoff = Instant.now().minus(7, ChronoUnit.DAYS);
+     *
+     * List<Partnership> res = partnershipRepository.findActiveByCategoriesExcludeSent(
+     *     top3CategoryCodes, today, userId, cutoff, PartnershipStatus.ACTIVE
+     * );
+     */
 }

--- a/backend/community/src/main/java/com/heyoung/domain/benefit/repository/UniversityPartnershipRepository.java
+++ b/backend/community/src/main/java/com/heyoung/domain/benefit/repository/UniversityPartnershipRepository.java
@@ -1,0 +1,11 @@
+package com.heyoung.domain.benefit.repository;
+
+import com.heyoung.domain.benefit.entity.UniversityPartnership;
+import com.heyoung.domain.university.entity.University;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface UniversityPartnershipRepository extends JpaRepository<UniversityPartnership, Long> {
+    List<UniversityPartnership> findTop5ByUniversityOrderByUseCountDesc(University university);
+}

--- a/backend/community/src/main/java/com/heyoung/domain/benefit/service/PartnershipService.java
+++ b/backend/community/src/main/java/com/heyoung/domain/benefit/service/PartnershipService.java
@@ -5,11 +5,16 @@ import com.heyoung.domain.benefit.entity.Category;
 import com.heyoung.domain.benefit.entity.Partnership;
 import com.heyoung.domain.benefit.repository.CategoryRepository;
 import com.heyoung.domain.benefit.repository.PartnershipRepository;
+import com.heyoung.domain.benefit.repository.UniversityPartnershipRepository;
+import com.heyoung.domain.university.entity.University;
 import com.heyoung.domain.university.entity.UserUniversity;
 import com.heyoung.domain.university.repository.UserUniversityRepository;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Instant;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -17,15 +22,19 @@ import java.util.stream.Collectors;
 
 @Service
 public class PartnershipService {
+    private static final List<Long> DEFAULT_CATEGORIES = List.of(1L, 2L, 3L); // 임시 값
+
     private final PartnershipRepository partnershipRepository;
     private final UserUniversityRepository userUniversityRepository;
 	private final CategoryRepository categoryRepository;
+    private final UniversityPartnershipRepository universityPartnershipRepository;
 
     public PartnershipService(PartnershipRepository partnershipRepository, UserUniversityRepository userUniversityRepository,
-		CategoryRepository categoryRepository) {
+		CategoryRepository categoryRepository, UniversityPartnershipRepository universityPartnershipRepository) {
         this.partnershipRepository = partnershipRepository;
         this.userUniversityRepository = userUniversityRepository;
 		this.categoryRepository = categoryRepository;
+        this.universityPartnershipRepository = universityPartnershipRepository;
     }
 
     // 모든 대학의 Partnership
@@ -63,4 +72,19 @@ public class PartnershipService {
 			.map(Category::getName)
 			.toList();
 	}
+
+    public List<Category> findTop5Categories(University university) {
+        List<Category> categories = universityPartnershipRepository.findTop5ByUniversityOrderByUseCountDesc(university).stream()
+                .map(universityPartnership -> universityPartnership.getPartnershipBranch().getPartnership().getCategory()).toList();
+
+        return categories.isEmpty() ? categoryRepository.findAllById(DEFAULT_CATEGORIES) : categories;
+    }
+
+    /** 카테고리 선호가 있을 때: 그 카테고리에서 유효/미전송 제휴 찾기 */
+    public List<Partnership> findActiveByCategoriesExcludeSent(
+            List<Category> cats, LocalDate today, Long userId, Instant cutoff
+    ) {
+        return partnershipRepository.findActiveByCategoriesExcludeSent(
+                cats, today, userId, cutoff);
+    }
 }

--- a/backend/community/src/main/java/com/heyoung/domain/notification/batch/config/NotificationBatchConfig.java
+++ b/backend/community/src/main/java/com/heyoung/domain/notification/batch/config/NotificationBatchConfig.java
@@ -1,0 +1,68 @@
+package com.heyoung.domain.notification.batch.config;
+
+import com.heyoung.domain.notification.repository.PushTokenRepository;
+import com.heyoung.domain.notification.service.DailyNotificationScheduler;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import java.time.ZoneId;
+import java.util.List;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class NotificationBatchConfig {
+
+    private final PushTokenRepository pushTokenRepository;
+    private final DailyNotificationScheduler dailyNotificationScheduler;
+
+    // KST 기준으로 사용자 시간대를 지정할 기본 값
+    private static final ZoneId DEFAULT_ZONE = ZoneId.of("Asia/Seoul");
+
+    @Bean
+    public Job notificatonReservationJob(JobRepository jobRepository,
+                                         Step notificationsReservationStep) {
+        return new JobBuilder("notificationReservationJob", jobRepository)
+                .start(notificationsReservationStep)
+                .build();
+    }
+
+    @Bean
+    public Step notificationReservationStep(JobRepository jobRepository,
+                                            PlatformTransactionManager transactionManager) {
+        return new StepBuilder("notificationsReservationStep", jobRepository)
+                .tasklet((contribution, chunkContext) -> {
+                    // 활성 사용자 집합 조회
+                    List<Long> candidates = pushTokenRepository.findDistinctByActiveUserIds();
+
+                    int total = 0, success = 0, skipped = 0, failed = 0;
+
+                    for(Long userId : candidates) {
+                        total++;
+
+                        try {
+                            // 사용자별 하루 3건 예약 로직 실행
+                            dailyNotificationScheduler.scheduleTodayTop3(userId, DEFAULT_ZONE);
+                            success++;
+                        } catch (Exception e) {
+                            failed++;
+                            log.warn("[notificationsReservations] userId = {} 예약 실패 : {}", userId, e.getMessage(), e);
+                        }
+                    }
+
+                    log.info("[notificationsReservation] done. total={}, success={}, skipped={}, failed={}",
+                            total, success, skipped, failed);
+
+                    return org.springframework.batch.repeat.RepeatStatus.FINISHED;
+                }, transactionManager).build();
+
+    }
+}

--- a/backend/community/src/main/java/com/heyoung/domain/notification/batch/scheduler/NightlyNotificationJobLauncher.java
+++ b/backend/community/src/main/java/com/heyoung/domain/notification/batch/scheduler/NightlyNotificationJobLauncher.java
@@ -1,0 +1,37 @@
+package com.heyoung.domain.notification.batch.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+
+@Slf4j
+@Configuration
+@EnableScheduling
+@RequiredArgsConstructor
+public class NightlyNotificationJobLauncher {
+
+    private final JobLauncher jobLauncher;
+    private final Job notificationsReservationJob;
+
+    // 매일 새벽(2:10 KST)에 예약 등록 배치 수행
+    // 서버가 UTC 일 경우, KST 기준으로 트리거됨.
+    @Scheduled(cron = "0 10 2 * * *", zone = "Asia/Seoul")
+    public void runNightly() {
+        try {
+            jobLauncher.run(
+                    notificationsReservationJob,
+                    new JobParametersBuilder()
+                            .addLong("run.id", System.currentTimeMillis()) // 재실행 구분
+                            .toJobParameters()
+            );
+            log.info("[NightlyNotificationJob] triggered");
+        } catch (Exception e) {
+            log.error("[NightlyNotificationJob] launch failed : {}", e.getMessage(), e);
+        }
+    }
+}

--- a/backend/community/src/main/java/com/heyoung/domain/notification/controller/NotificationController.java
+++ b/backend/community/src/main/java/com/heyoung/domain/notification/controller/NotificationController.java
@@ -1,0 +1,115 @@
+package com.heyoung.domain.notification.controller;
+
+import com.heyoung.domain.notification.entity.Notification;
+import com.heyoung.domain.notification.service.DailyNotificationScheduler;
+import com.heyoung.domain.notification.service.NotificationQueryService;
+import com.heyoung.domain.notification.service.NotificationSendService;
+import com.heyoung.global.exception.BaseResponse;
+import com.heyoung.global.exception.ResponseCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+@Slf4j
+@RestController
+//@Profile({"local", "dev"})
+@RequiredArgsConstructor
+@Tag(name="알림 테스트 API", description = "알림 기능을 테스트할 수 있는 API입니다.")
+@RequestMapping("/notifications")
+public class NotificationController {
+
+    private final JobLauncher jobLauncher;
+    private final Job notificationsReservationJob;
+
+    private final NotificationSendService notificationSendService;
+    private final NotificationQueryService notificationQueryService;
+    private final DailyNotificationScheduler dailyNotificationScheduler;
+
+    @GetMapping("/test")
+    @Operation(
+            summary="알림 예약 로직 테스트",
+            description="(1) 유저 선호 기반으로 오늘/내일 전송 예약 3건 생성 → (2) 생성된 예약 일부를 확인용으로 반환"
+    )
+    public BaseResponse<List<Notification>> testNotification(
+            @RequestParam Long userId,
+            @RequestParam(defaultValue = "Asia/Seoul") String tz
+    ) {
+        List<Notification> upcoming = null;
+        try {
+            ZoneId zone = ZoneId.of(tz);
+            dailyNotificationScheduler.scheduleTodayTop3(userId, zone);
+
+            // 방금 예약된 것들 확인(지금 시각 이후 36시간 안에 잡힌 예약 상위 10건)
+            Instant now = Instant.now();
+            Instant until = now.plusSeconds(36 * 3600);
+            upcoming = notificationQueryService.findUserScheduledBetween(userId, now, until);
+
+        } catch (Exception e) {
+            log.error("testNotification failed", e);
+        }
+
+        return BaseResponse.onSuccess(upcoming, ResponseCode.OK);
+    }
+
+    @PostMapping("/run")
+    @Operation(summary="배치가 잘 동작하는 테스트 하는 controller", description = "배치가 잘 동작하는지 확인.")
+    public BaseResponse<String> run() {
+        try {
+            jobLauncher.run(
+                    notificationsReservationJob,
+                    new JobParametersBuilder()
+                            .addLong("run.id", System.currentTimeMillis())
+                            .toJobParameters()
+            );
+            return BaseResponse.onSuccess("notificationsReservationJob launched", ResponseCode.OK);
+        } catch (Exception e) {
+            log.error("launch failed", e);
+            return BaseResponse.onFailure("launch failed : " + e.getMessage(), ResponseCode._INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    @PostMapping("/push")
+    @Operation(
+            summary="즉시 푸시 전송 테스트",
+            description="해당 유저의 '발송 시각이 지났지만 아직 미발송' 예약을 최대 N건 찾아 FCM으로 즉시 전송"
+    )
+    public BaseResponse<String> pushNotifications(@RequestParam Long userId) {
+
+        try {
+            int sent = notificationSendService.sendDueForUser(userId);
+            return BaseResponse.onSuccess("sent=" + sent, ResponseCode.OK);
+        } catch (Exception e) {
+            log.error("pushNotifications failed", e);
+            return BaseResponse.onFailure("pushNotifications failed: " + e.getMessage(), ResponseCode._INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    @GetMapping
+    @Operation(
+            summary="사용자 예약/발송 목록 조회",
+            description="유저 알림(최근순) 상위 N건을 확인"
+    )
+    public BaseResponse<List<Notification>> getNotification(@RequestParam Long userId) { // 무한 스크롤
+        List<Notification> list = null;
+        try {
+            Instant now = Instant.now();
+            Instant sevenDaysAgo = now.minus(7, ChronoUnit.DAYS);
+            list = notificationQueryService.findUserScheduledBetween(userId, sevenDaysAgo, now);
+        } catch (Exception e) {
+            log.error("getNotification failed : {}", e.getMessage());
+        }
+
+        return BaseResponse.onSuccess(list, ResponseCode.OK);
+    }
+}

--- a/backend/community/src/main/java/com/heyoung/domain/notification/controller/PushTokenController.java
+++ b/backend/community/src/main/java/com/heyoung/domain/notification/controller/PushTokenController.java
@@ -1,0 +1,44 @@
+package com.heyoung.domain.notification.controller;
+
+import com.heyoung.domain.notification.dto.request.PushTokenDtos;
+import com.heyoung.domain.notification.entity.PushToken;
+import com.heyoung.domain.notification.service.PushTokenService;
+import com.heyoung.global.exception.BaseResponse;
+import com.heyoung.global.exception.ResponseCode;
+import com.heyoung.global.webconfig.ManagerId;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name="알림 토큰을 저장하는 API 입니다.", description = "프론트에서 제휴 토큰을 넘겨주면 저장하는 API 입니다.")
+@RestController
+@RequestMapping("/token")
+@RequiredArgsConstructor
+public class PushTokenController {
+
+    private final PushTokenService pushTokenService;
+
+    @PostMapping("/register")
+    @Operation(summary="사용자 토큰을 저장하는 API", description = "NotificationChannel 은 PUSH(FCM), EXPO 가 존재")
+    public BaseResponse<PushTokenDtos.TokenResponse> register(@ManagerId Long userId, @Valid @RequestBody PushTokenDtos.RegisterRequest request) {
+        PushToken pt = pushTokenService.register(userId, request);
+        return BaseResponse.onSuccess(new PushTokenDtos.TokenResponse(
+                pt.getId(), pt.getChannel(), pt.getActive()
+        ), ResponseCode.OK);
+    }
+
+    @PostMapping("/deactivate")
+    @Operation(summary="사용자 토큰을 비활성화하는 API", description = "NotificationChannel 은 PUSH(FCM), EXPO 가 존재")
+    public BaseResponse<PushTokenDtos.TokenResponse> deactivate(@ManagerId Long userId, @Valid @RequestBody PushTokenDtos.DeactivateRequest req) {
+        PushToken pt = pushTokenService.deactivate(userId, req.channel(), req.token());
+        return BaseResponse.onSuccess(new PushTokenDtos.TokenResponse(
+                pt.getId(), pt.getChannel(), pt.getActive()
+        ), ResponseCode.OK);
+    }
+
+}

--- a/backend/community/src/main/java/com/heyoung/domain/notification/dto/request/PushTokenDtos.java
+++ b/backend/community/src/main/java/com/heyoung/domain/notification/dto/request/PushTokenDtos.java
@@ -1,0 +1,27 @@
+package com.heyoung.domain.notification.dto.request;
+
+import com.heyoung.global.enums.NotificationChannel;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public class PushTokenDtos {
+
+    public record RegisterRequest(
+            @NotNull NotificationChannel channel,
+            @NotBlank String token,
+            String appVersion,
+            String osVersion,
+            String deviceVersion
+    ) {}
+
+    public record DeactivateRequest(
+            @NotNull NotificationChannel channel,
+            @NotBlank String token
+    ) {}
+
+    public record TokenResponse(
+            Long id,
+            NotificationChannel channel,
+            boolean active
+    ) {}
+}

--- a/backend/community/src/main/java/com/heyoung/domain/notification/entity/Notification.java
+++ b/backend/community/src/main/java/com/heyoung/domain/notification/entity/Notification.java
@@ -1,5 +1,6 @@
 package com.heyoung.domain.notification.entity;
 
+import com.heyoung.domain.benefit.entity.Partnership;
 import com.heyoung.global.entity.BaseEntity;
 import com.heyoung.global.enums.NotificationChannel;
 import com.heyoung.global.enums.NotificationType;
@@ -8,11 +9,14 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
 
 /**
  * 알림 예약 저장소. 이 DB 의 send_at 을 조회하여 알림을 발송시키는 것.
  */
-@Entity @Getter
+@Entity @Getter @Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Notification extends BaseEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -31,7 +35,7 @@ public class Notification extends BaseEntity {
     private NotificationType type;
 
     @Enumerated(EnumType.STRING)
-    @Column(length = 8, nullable = false)
+    @Column(length = 32, nullable = false)
     private NotificationChannel channel;
 
     @Column(length = 500, nullable = false)
@@ -41,6 +45,37 @@ public class Notification extends BaseEntity {
     private String imagePath;
 
     @Enumerated(EnumType.STRING)
-    @Column(length = 8, nullable = false)
+    @Column(length = 32, nullable = false)
     private SendStatus sendStatus;
+
+    @Column(nullable = false)
+    private Instant scheduledAt; // 발송 예약 시각
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "partnership_id", nullable = false)
+    private Partnership partnership;
+
+    public static Notification createReservation(
+            Long userId, Partnership p,
+            String title, String content,
+            NotificationType type, NotificationChannel channel,
+            String clickUrl, String imagePath,
+            Instant scheduledAt
+    ) {
+        Notification n = new Notification();
+        n.userId = userId;
+        n.partnership = p;
+        n.title = title;
+        n.content = content;
+        n.type = type;
+        n.channel = channel;
+        n.clickUrl = clickUrl;
+        n.imagePath = imagePath;
+        n.scheduledAt = scheduledAt;
+        n.sendStatus = SendStatus.SCHEDULED;
+        return n;
+    }
+
+    public void markSent()   { this.sendStatus = SendStatus.SENT; }
+    public void markFailed() { this.sendStatus = SendStatus.FAILED; }
 }

--- a/backend/community/src/main/java/com/heyoung/domain/notification/entity/NotificationLog.java
+++ b/backend/community/src/main/java/com/heyoung/domain/notification/entity/NotificationLog.java
@@ -50,5 +50,23 @@ public class NotificationLog extends BaseEntity {
     @Column(nullable = false, length = 160)
     private String uniqKey;
 
+    public static NotificationLog sentOf(Notification notification, Long userId, String uniqKey) {
+        NotificationLog log = new NotificationLog();
+        log.notification = notification;
+        log.userId = userId;
+        log.sendStatus = com.heyoung.global.enums.SendStatus.SENT;
+        log.uniqKey = uniqKey;
+        log.occurredAt = java.time.Instant.now();
+        return log;
+    }
 
+    public static NotificationLog failedOf(Notification notification, Long userId, String uniqKey) {
+        NotificationLog log = new NotificationLog();
+        log.notification = notification;
+        log.userId = userId;
+        log.sendStatus = com.heyoung.global.enums.SendStatus.FAILED;
+        log.uniqKey = uniqKey;
+        log.occurredAt = java.time.Instant.now();
+        return log;
+    }
 }

--- a/backend/community/src/main/java/com/heyoung/domain/notification/entity/PushToken.java
+++ b/backend/community/src/main/java/com/heyoung/domain/notification/entity/PushToken.java
@@ -19,14 +19,14 @@ import java.time.LocalDateTime;
         name = "push_token",
         uniqueConstraints = {
                 // 긴 token 대신 tokenHash 로 유니크 제약
-                @UniqueConstraint(name = "uq_push_token_channel_hash", columnNames = {"channel", "tokenHash"})
+                @UniqueConstraint(name = "uq_push_token_channel_hash", columnNames = {"channel", "token_hash"})
         },
         indexes = {
                 // 활성 토큰 조회 (userId + active 조합)
-                @Index(name = "idx_push_token_user_active", columnList = "userId, active"),
+                @Index(name = "idx_push_token_user_active", columnList = "user_id, active"),
                 // 오래된/미사용 토큰 찾기
-                @Index(name = "idx_push_token_last_seen", columnList = "lastSeenAt"),
-                @Index(name = "idx_push_token_last_sent", columnList = "lastSentAt")
+                @Index(name = "idx_push_token_last_seen", columnList = "last_seen_at"),
+                @Index(name = "idx_push_token_last_sent", columnList = "last_sent_at")
         }
 )
 public class PushToken extends BaseEntity {
@@ -69,4 +69,50 @@ public class PushToken extends BaseEntity {
 
     @Column(length = 64)
     private String deviceVersion;
+
+    public static PushToken create(Long userId,
+                                   NotificationChannel channel,
+                                   String token,
+                                   String tokenHash,
+                                   String appVersion,
+                                   String osVersion,
+                                   String deviceVersion,
+                                   java.time.LocalDateTime now) {
+        PushToken pt = new PushToken();
+        pt.userId = userId;
+        pt.channel = channel;
+        pt.token = token;
+        pt.tokenHash = tokenHash;
+        pt.active = true;
+        pt.failCount = 0;
+        pt.invalidType = null;
+        pt.lastSeenAt = now;
+        pt.appVersion = appVersion;
+        pt.osVersion = osVersion;
+        pt.deviceVersion = deviceVersion;
+        return pt;
+    }
+
+    // 기존 레코드 갱신
+    public void refresh(Long userId,
+                        String token,
+                        String appVersion,
+                        String osVersion,
+                        String deviceVersion,
+                        java.time.LocalDateTime now) {
+        this.userId = userId;          // 토큰이 다른 유저로 이관되면 덮어쓰기
+        this.token = token;            // 원문 토큰 보관
+        this.active = true;            // 활성화
+        this.failCount = 0;            // 실패 카운터 리셋
+        this.invalidType = null;       // 무효 사유 초기화
+        this.lastSeenAt = now;
+        if (appVersion != null) this.appVersion = appVersion;
+        if (osVersion != null) this.osVersion = osVersion;
+        if (deviceVersion != null) this.deviceVersion = deviceVersion;
+    }
+
+    public void deactivate(java.time.LocalDateTime now) {
+        this.active = false;
+        this.lastSeenAt = now;
+    }
 }

--- a/backend/community/src/main/java/com/heyoung/domain/notification/repository/NotificationLogRepository.java
+++ b/backend/community/src/main/java/com/heyoung/domain/notification/repository/NotificationLogRepository.java
@@ -1,0 +1,28 @@
+package com.heyoung.domain.notification.repository;
+
+import com.heyoung.domain.notification.entity.NotificationLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.Instant;
+import java.util.Set;
+
+public interface NotificationLogRepository extends JpaRepository<NotificationLog, Long> {
+    /**
+     * 최근 cutoff 이후, 해당 사용자가 받은 알림 중 제휴가 연결된 것의 partnershipId 목록.
+     * - SendStatus 조건을 더 넣고 싶으면 and nl.sendStatus = ... 추가하면 됨.
+     */
+    @Query("""
+        select distinct n.partnership.id
+        from NotificationLog nl
+        join nl.notification n
+        where nl.userId = :userId
+          and nl.occurredAt >= :cutoff
+          and n.partnership is not null
+    """)
+    Set<Long> findSentPartnershipIdsSince(@Param("userId") Long userId,
+                                          @Param("cutoff") Instant cutoff);
+
+    boolean existsByUniqKey(String uniqKey);
+}

--- a/backend/community/src/main/java/com/heyoung/domain/notification/repository/NotificationRepository.java
+++ b/backend/community/src/main/java/com/heyoung/domain/notification/repository/NotificationRepository.java
@@ -1,0 +1,55 @@
+package com.heyoung.domain.notification.repository;
+
+import com.heyoung.domain.benefit.entity.Partnership;
+import com.heyoung.domain.notification.entity.Notification;
+import com.heyoung.global.enums.NotificationChannel;
+import com.heyoung.global.enums.SendStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.Instant;
+import java.util.List;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    // 채널 필터 없이 due
+    List<Notification> findTop100BySendStatusAndScheduledAtBeforeOrderByScheduledAtAsc(
+            SendStatus sendStatus, Instant before);
+
+    boolean existsByUserIdAndPartnershipAndScheduledAtBetween(
+            Long userId, Partnership partnership, Instant from, Instant to
+    );
+
+    // 테스트용
+    /** 지금 보낼 것(스케줄 시각 지났고 아직 미발송) */
+    @Query("""
+        select n from Notification n
+        where n.userId = :userId
+          and n.scheduledAt <= :now
+          and (n.sendStatus is null or n.sendStatus <> com.heyoung.global.enums.SendStatus.SENT)
+        order by n.scheduledAt asc
+    """)
+    List<Notification> findDueForUser(@Param("userId") Long userId,
+                                      @Param("now") Instant now);
+
+    /** 최근 생성기준(테스트용 목록 조회) */
+    @Query("""
+        select n from Notification n
+        where n.userId = :userId
+        order by n.createdDate desc
+    """)
+    List<Notification> findByUserIdOrderByCreatedAtDesc(@Param("userId") Long userId);
+
+    /** 특정 구간 스케줄 조회(예약 확인 용도) */
+    @Query("""
+        select n from Notification n
+        where n.userId = :userId
+          and n.scheduledAt between :from and :to
+        order by n.scheduledAt asc
+    """)
+    List<Notification> findScheduledBetween(@Param("userId") Long userId,
+                                            @Param("from") Instant from,
+                                            @Param("to") Instant to);
+
+}

--- a/backend/community/src/main/java/com/heyoung/domain/notification/repository/PushTokenRepository.java
+++ b/backend/community/src/main/java/com/heyoung/domain/notification/repository/PushTokenRepository.java
@@ -1,0 +1,65 @@
+package com.heyoung.domain.notification.repository;
+
+import com.heyoung.domain.notification.entity.PushToken;
+import com.heyoung.global.enums.InvalidType;
+import com.heyoung.global.enums.NotificationChannel;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface PushTokenRepository extends JpaRepository<PushToken, Long> {
+
+    @Query("select distinct pt.userId from PushToken pt where pt.active = true")
+    List<Long> findDistinctByActiveUserIds();
+
+    // PushToken 에서 활성 사용자 뽑기(배치 대상)
+    List<PushToken> findByUserIdAndChannelAndActiveTrue(Long userId, NotificationChannel channel);
+
+    @Modifying
+    @Query("update PushToken t set t.lastSentAt = :ts, t.failCount = 0 where t.id in :ids")
+    int touchSuccess(List<Long> ids, LocalDateTime ts);
+
+    @Modifying
+    @Query("update PushToken t set t.failCount = t.failCount + 1 where t.id = :id")
+    int increaseFailCount(Long id);
+
+    Optional<PushToken> findByChannelAndTokenHash(NotificationChannel channel, String tokenHash);
+
+    Optional<PushToken> findByUserIdAndChannelAndTokenHash(Long userId, NotificationChannel channel, String tokenHash);
+
+    List<PushToken> findAllByUserIdAndChannelAndActive(Long userId, NotificationChannel channel, Boolean active);
+
+
+    @Modifying
+    @Query("update PushToken t set t.active = false where t.id = :id")
+    int deactivate(Long id);
+
+    /** 특정 유저의 활성화된 채널별 토큰만 조회 */
+    @Query("""
+        select t.token
+        from PushToken t
+        where t.userId = :userId
+          and t.channel = :channel
+          and t.active = true
+    """)
+    List<String> findActiveTokensByUserIdAndChannel(@Param("userId") Long userId,
+                                                    @Param("channel") NotificationChannel channel);
+
+    /** 잘못된(등록 해제 등) 토큰을 비활성화 처리 */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+        update PushToken t
+           set t.active = false,
+               t.invalidType = :invalid
+         where t.token = :token
+           and t.channel = :channel
+    """)
+    int markInactiveByToken(@Param("token") String token,
+                            @Param("channel") NotificationChannel channel,
+                            @Param("invalid") InvalidType invalidType);
+}

--- a/backend/community/src/main/java/com/heyoung/domain/notification/service/DailyNotificationScheduler.java
+++ b/backend/community/src/main/java/com/heyoung/domain/notification/service/DailyNotificationScheduler.java
@@ -1,0 +1,7 @@
+package com.heyoung.domain.notification.service;
+
+import java.time.ZoneId;
+
+public interface DailyNotificationScheduler {
+    void scheduleTodayTop3(Long userId, ZoneId userZone);
+}

--- a/backend/community/src/main/java/com/heyoung/domain/notification/service/DailyNotificationSchedulerImpl.java
+++ b/backend/community/src/main/java/com/heyoung/domain/notification/service/DailyNotificationSchedulerImpl.java
@@ -1,0 +1,168 @@
+package com.heyoung.domain.notification.service;
+
+import com.heyoung.domain.benefit.entity.Category;
+import com.heyoung.domain.benefit.entity.Partnership;
+import com.heyoung.domain.benefit.service.PartnershipService;
+import com.heyoung.domain.notification.entity.Notification;
+import com.heyoung.domain.notification.repository.NotificationLogRepository;
+import com.heyoung.domain.notification.repository.NotificationRepository;
+import com.heyoung.domain.recommendation.repository.UserCategoryRepository;
+import com.heyoung.domain.recommendation.repository.UserHourHistRepository;
+import com.heyoung.domain.university.entity.University;
+import com.heyoung.domain.university.service.UserUniversityQueryService;
+import com.heyoung.global.enums.HourBucket;
+import com.heyoung.global.enums.NotificationChannel;
+import com.heyoung.global.enums.NotificationType;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.*;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class DailyNotificationSchedulerImpl implements DailyNotificationScheduler {
+    private final UserUniversityQueryService userUniversityQueryService;
+    private final NotificationLogRepository notificationLogRepository;
+    private final NotificationRepository notificationRepository;
+    private final PartnershipService partnershipService;
+
+    // 선호 없을 때 기본 시간대 (정오, 18시, 21시)
+    private static final List<HourBucket> DEFAULT_HOURS =
+            List.of(HourBucket.HOUR_12, HourBucket.HOUR_18, HourBucket.HOUR_21);
+
+    // 최근 N 일 내 보낸 제휴는 제외.
+    private static final int EXCLUDE_DAYS = 7;
+
+    // 하루 예약 개수
+    private static final int RESERVATIONS_PER_DAY = 3;
+
+    private static final String BASE_URL = "http://localhost:8081";
+    private final UserCategoryRepository userCategoryRepository;
+    private final UserHourHistRepository userHourHistRepository;
+
+    @Transactional
+    public void scheduleTodayTop3(Long userId, ZoneId userZone) {
+        LocalDate today = LocalDate.now(userZone);
+        Instant now = Instant.now();
+        Instant cutoff = now.minus(EXCLUDE_DAYS, ChronoUnit.DAYS);
+
+        // 선호 Top 3
+        List<Category> cats = top3Categories(userId);
+        List<HourBucket> hours = top3HourBuckets(userId);
+
+        // 오늘(또는 내일) 전송 시각 3개 계산(각 시간대 30분 전)
+        List<Instant> sendTimes = computeThreeSendTimes(userZone, hours, now);
+
+        // 최근 7일 동안 보낸 제휴 id 모음
+        Set<Long> sentPartnershipIds = notificationLogRepository.findSentPartnershipIdsSince(userId, cutoff);
+
+        // 카테고리/시간대 라운드로빈 매칭하여 제휴 조회 + 예약 생성
+        Set<Long> reservedPartnershipIds = new HashSet<>();
+
+        List<Partnership> candidates = pickPartnership(userId, cats, today, cutoff, reservedPartnershipIds);
+
+        // 이미 보낸 것(sentPartnershipIds) + 이번 배치에서 중복 예약 방지
+        List<Partnership> chosen = new ArrayList<>(RESERVATIONS_PER_DAY);
+        Set<Long> reservedIds = new HashSet<>();
+
+        for(Partnership p : candidates) {
+
+            if(sentPartnershipIds.contains(p.getId())) continue; // 최근 7일 내 보낸 제휴 제외
+            if(reservedIds.contains(p.getId())) continue; // 같은 배치 중복 제외
+
+            // 같은 날 같은 제휴 이미 예약돼 있으면 스킵
+            Instant dayStart = today.atStartOfDay(userZone).toInstant();
+            Instant dayEnd = dayStart.plus(1, ChronoUnit.DAYS);
+
+            if(notificationRepository.existsByUserIdAndPartnershipAndScheduledAtBetween(userId, p, dayStart, dayEnd)) continue;
+
+            chosen.add(p);
+            reservedIds.add(p.getId());
+            if(chosen.size() == RESERVATIONS_PER_DAY) break;
+
+
+        }
+
+        // 선택된 최대 3개에 대해 알림 예약 생성
+        for(int i = 0; i<chosen.size(); i++) {
+            Partnership partnership = chosen.get(i);
+            Instant scheduleAt = sendTimes.get(i);
+
+            // 예약 저장(해커톤 스코프로 간단 텍스트)
+            Notification n = Notification.createReservation(
+                    userId,
+                    partnership,
+                    "[제휴 혜택] " + partnership.getCompanyName(),
+                    partnership.getNotes() + " " + partnership.getDiscountRate(),
+                    NotificationType.PAYMENT_BASED,
+                    NotificationChannel.INAPP,
+                    BASE_URL+"/benefit/"+partnership.getId(),
+                    partnership.getPartnershipImages().get(0).getImageUrl(),
+                    scheduleAt);
+
+            notificationRepository.save(n);
+
+        }
+
+
+    }
+
+    private List<Category> top3Categories(Long userId) {
+        List<Category> categories = userCategoryRepository.findTop5ByUserIdOrderByUseCountDesc(userId).stream()
+                .map(userCategory -> userCategory.getCategory()).toList();
+
+        University university = userUniversityQueryService.getUniversityByUserId(userId);
+        List<Category> defaults = partnershipService.findTop5Categories(university);
+
+        return categories.isEmpty() ? defaults : categories;
+    }
+
+    private List<HourBucket> top3HourBuckets(Long userId) {
+        List<HourBucket> hourBuckets = userHourHistRepository.findTop5ByUserIdOrderByUseCountDesc(userId).stream()
+                .map(userHourHist -> userHourHist.getHourBucket()).toList();
+        List<HourBucket> defaults = userHourHistRepository.findAllByHourBucketIn(DEFAULT_HOURS).stream()
+                .map(hourBucket -> hourBucket.getHourBucket()).toList();
+        return hourBuckets.isEmpty() ? DEFAULT_HOURS : hourBuckets;
+    }
+
+    /**
+     * 각 시간대의 해당일 버킷 시작시각 - 30분 이 현재보다 과거면 다음날로 밈.
+     */
+    private List<Instant> computeThreeSendTimes(ZoneId zone, List<HourBucket> hours, Instant now) {
+        LocalDate today = LocalDate.now(zone);
+        List<Instant> result = new ArrayList<>(RESERVATIONS_PER_DAY);
+        for(int i = 0; i<RESERVATIONS_PER_DAY; i++) {
+            HourBucket hb = hours.get(i % hours.size());
+            LocalTime bucketStart = HourBucket.startTimeOr(LocalTime.of(12, 0), hb);
+            Instant candidate = ZonedDateTime.of(today, bucketStart, zone).minusMinutes(30).toInstant();
+            if (candidate.isBefore(now)) {
+                candidate = ZonedDateTime.of(today.plusDays(1), bucketStart, zone).minusMinutes(30).toInstant();
+            }
+            result.add(candidate);
+        }
+        return result;
+    }
+
+    // 카테고리 선호로 검색
+    private List<Partnership> pickPartnership(Long userId,
+                                           List<Category> categories,
+                                           LocalDate today,
+                                           Instant cutoff,
+                                           Set<Long> excludeIds) {
+        List<Partnership> candidates = partnershipService.findActiveByCategoriesExcludeSent(
+                categories, today, userId, cutoff);
+
+        List<Partnership> result = new ArrayList<>();
+        for(Partnership p : candidates) {
+            if(!excludeIds.contains(p.getId())) result.add(p);
+        }
+
+        return result;
+    }
+}

--- a/backend/community/src/main/java/com/heyoung/domain/notification/service/NotificationQueryService.java
+++ b/backend/community/src/main/java/com/heyoung/domain/notification/service/NotificationQueryService.java
@@ -1,0 +1,11 @@
+package com.heyoung.domain.notification.service;
+
+import com.heyoung.domain.notification.entity.Notification;
+
+import java.time.Instant;
+import java.util.List;
+
+public interface NotificationQueryService {
+    List<Notification> findUserRecent(Long userId);
+    List<Notification> findUserScheduledBetween(Long userId, Instant from, Instant to);
+}

--- a/backend/community/src/main/java/com/heyoung/domain/notification/service/NotificationQueryServiceImpl.java
+++ b/backend/community/src/main/java/com/heyoung/domain/notification/service/NotificationQueryServiceImpl.java
@@ -1,0 +1,24 @@
+package com.heyoung.domain.notification.service;
+
+import com.heyoung.domain.notification.entity.Notification;
+import com.heyoung.domain.notification.repository.NotificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationQueryServiceImpl implements NotificationQueryService {
+    private final NotificationRepository notificationRepository;
+
+    public List<Notification> findUserRecent(Long userId) {
+        return notificationRepository.findByUserIdOrderByCreatedAtDesc(userId);
+    }
+
+    public List<Notification> findUserScheduledBetween(Long userId, Instant from, Instant to) {
+        return notificationRepository.findScheduledBetween(userId, from, to);
+    }
+}

--- a/backend/community/src/main/java/com/heyoung/domain/notification/service/NotificationSendService.java
+++ b/backend/community/src/main/java/com/heyoung/domain/notification/service/NotificationSendService.java
@@ -1,0 +1,9 @@
+package com.heyoung.domain.notification.service;
+
+public interface NotificationSendService {
+    /**
+     * 해당 유저의 "발송 시각이 지났고 아직 미발송"인 예약을 최대 limit개 전송.
+     * @return 성공적으로 보낸 개수
+     */
+    int sendDueForUser(Long userId);
+}

--- a/backend/community/src/main/java/com/heyoung/domain/notification/service/NotificationSendServiceImpl.java
+++ b/backend/community/src/main/java/com/heyoung/domain/notification/service/NotificationSendServiceImpl.java
@@ -1,0 +1,87 @@
+package com.heyoung.domain.notification.service;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.Message;
+import com.heyoung.domain.notification.entity.Notification;
+import com.heyoung.domain.notification.entity.NotificationLog;
+import com.heyoung.domain.notification.entity.PushToken;
+import com.heyoung.domain.notification.repository.NotificationLogRepository;
+import com.heyoung.domain.notification.repository.NotificationRepository;
+import com.heyoung.domain.notification.repository.PushTokenRepository;
+import com.heyoung.global.enums.NotificationChannel;
+import com.heyoung.global.enums.SendStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NotificationSendServiceImpl implements NotificationSendService {
+
+    private final NotificationRepository notificationRepository;
+    private final PushTokenRepository pushTokenRepository;
+    private final NotificationLogRepository notificationLogRepository;
+    private final FirebaseMessaging firebaseMessaging; // FirebaseApp 초기화는 기존 구성 사용
+
+    @Override
+    @Transactional
+    public int sendDueForUser(Long userId) {
+        Instant now = Instant.now();
+
+        List<Notification> due = notificationRepository.findDueForUser(userId, now);
+
+        int success = 0;
+        for (Notification n : due) {
+            try {
+                // 유저 활성 토큰 가져오기(최소 1개)
+                List<PushToken> tokens = pushTokenRepository.findByUserIdAndChannelAndActiveTrue(userId, NotificationChannel.PUSH);
+                if (tokens.isEmpty()) {
+                    log.warn("no active token for userId={}", userId);
+                    markFailed(n, "NO_TOKEN");
+                    continue;
+                }
+
+                // 여기서는 첫 토큰만 사용(테스트 목적). 멀티 토큰 전송은 loop/Topic 로 확장
+                String token = tokens.get(0).getToken();
+
+                Message msg = Message.builder()
+                        .setToken(token)
+                        .setNotification(com.google.firebase.messaging.Notification.builder()
+                                .setTitle(n.getTitle())
+                                .setBody(n.getContent())
+                                .build())
+                        .putData("clickUrl", n.getClickUrl())
+                        .putData("imagePath", n.getImagePath())
+                        .build();
+
+                String messageId = firebaseMessaging.send(msg);
+                log.info("FCM sent: messageId={}, notifId={}", messageId, n.getId());
+
+                // 로그 적재 & 상태 갱신
+                NotificationLog logEntity = NotificationLog.sentOf(n, userId, "FCM:" + messageId);
+                notificationLogRepository.save(logEntity);
+
+                n.setSendStatus(SendStatus.SENT);
+                notificationRepository.save(n);
+
+                success++;
+            } catch (Exception ex) {
+                log.error("send failed, notifId={}", n.getId(), ex);
+                markFailed(n, ex.getClass().getSimpleName());
+            }
+        }
+        return success;
+    }
+
+    private void markFailed(Notification n, String reason) {
+        n.setSendStatus(SendStatus.FAILED);
+        notificationRepository.save(n);
+        notificationLogRepository.save(NotificationLog.failedOf(n, n.getUserId(), reason));
+    }
+
+}

--- a/backend/community/src/main/java/com/heyoung/domain/notification/service/NotificationsDispatchService.java
+++ b/backend/community/src/main/java/com/heyoung/domain/notification/service/NotificationsDispatchService.java
@@ -1,0 +1,5 @@
+package com.heyoung.domain.notification.service;
+
+public interface NotificationsDispatchService {
+    void dispatchDueNotifications();
+}

--- a/backend/community/src/main/java/com/heyoung/domain/notification/service/NotificationsDispatchServiceImpl.java
+++ b/backend/community/src/main/java/com/heyoung/domain/notification/service/NotificationsDispatchServiceImpl.java
@@ -1,0 +1,137 @@
+package com.heyoung.domain.notification.service;
+
+import com.heyoung.domain.notification.entity.Notification;
+import com.heyoung.domain.notification.entity.NotificationLog;
+import com.heyoung.domain.notification.entity.PushToken;
+import com.heyoung.domain.notification.repository.NotificationLogRepository;
+import com.heyoung.domain.notification.repository.NotificationRepository;
+import com.heyoung.domain.notification.repository.PushTokenRepository;
+import com.heyoung.global.enums.NotificationChannel;
+import com.heyoung.global.enums.SendStatus;
+import com.heyoung.global.infra.expo.ExpoPushSender;
+import com.heyoung.global.infra.fcm.FcmSender;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class NotificationsDispatchServiceImpl implements NotificationsDispatchService {
+
+    private final NotificationRepository notificationRepository;
+    private final PushTokenRepository pushTokenRepository;
+    private final NotificationLogRepository notificationLogRepository;
+
+    // 선택: 둘 다 쓸 수 있게 의존성 주입 (없으면 없는대로 빈 등록 제외)
+    private final Optional<FcmSender> fcmSender;
+    private final Optional<ExpoPushSender> expoSender;
+
+    @Scheduled(fixedDelayString = "${notify.dispatch.fixed-delay-ms:30000}", initialDelay = 15000)
+    @Transactional
+    public void dispatchDueNotifications() {
+        log.info("알림 처리 스케줄러 실행");
+        Instant now = Instant.now();
+
+        List<Notification> due = notificationRepository
+                .findTop100BySendStatusAndScheduledAtBeforeOrderByScheduledAtAsc(SendStatus.SCHEDULED, now);
+
+        for (Notification n : due) {
+            try {
+                processOne(n);
+            } catch (Exception ex) {
+                log.error("processOne failed id={}", n.getId(), ex);
+                // 재시도 전략: 상태 유지(SCHEDULED) or FAILED 로 마킹 등 정책에 맞게
+            }
+        }
+    }
+
+    private void processOne(Notification n) throws Exception {
+        String uniq = "SEND:" + n.getId();
+
+        // 이미 전송 로그가 있다면(멱등) 상태만 SENT 로 만들고 스킵할 수도 있음
+        if (notificationLogRepository.existsByUniqKey(uniq)) {
+            n.setSendStatus(SendStatus.SENT);
+            return;
+        }
+
+        // 채널 별 토큰
+        List<PushToken> expoTokens = expoSender.isPresent()
+                ? pushTokenRepository.findByUserIdAndChannelAndActiveTrue(n.getUserId(), NotificationChannel.EXPO)
+                : List.of();
+
+        List<PushToken> fcmTokens = fcmSender.isPresent()
+                ? pushTokenRepository.findByUserIdAndChannelAndActiveTrue(n.getUserId(), NotificationChannel.PUSH)
+                : List.of();
+
+        boolean anySuccess = false;
+
+        // 1) EXPO
+        if (!expoTokens.isEmpty() && expoSender.isPresent()) {
+            anySuccess |= sendAndTouchTokensViaExpo(n, expoTokens);
+        }
+
+        // 2) FCM
+        if (!fcmTokens.isEmpty() && fcmSender.isPresent()) {
+            anySuccess |= sendAndTouchTokensViaFcm(n, fcmTokens);
+        }
+
+        // 결과 기록
+        if (anySuccess) {
+            n.setSendStatus(SendStatus.SENT);
+            notificationLogRepository.save(NotificationLog.sentOf(n, n.getUserId(), uniq));
+        } else {
+            n.setSendStatus(SendStatus.FAILED);
+            notificationLogRepository.save(NotificationLog.failedOf(n, n.getUserId(), uniq));
+        }
+    }
+
+    private boolean sendAndTouchTokensViaExpo(Notification n, List<PushToken> tokenEntities) throws Exception {
+        Map<String, Long> tokenToId = tokenEntities.stream()
+                .collect(Collectors.toMap(PushToken::getToken, PushToken::getId, (a, b) -> a, LinkedHashMap::new));
+
+        Map<String, Boolean> result = expoSender.get()
+                .sendMulticast(n, tokenEntities.stream().map(PushToken::getToken).toList());
+
+        return touchTokens(tokenToId, result);
+    }
+
+    private boolean sendAndTouchTokensViaFcm(Notification n, List<PushToken> tokenEntities) throws Exception {
+        Map<String, Long> tokenToId = tokenEntities.stream()
+                .collect(Collectors.toMap(PushToken::getToken, PushToken::getId, (a, b) -> a, LinkedHashMap::new));
+
+        Map<String, Boolean> result = fcmSender.get()
+                .sendMulticast(n, tokenEntities.stream().map(PushToken::getToken).toList());
+
+        return touchTokens(tokenToId, result);
+    }
+
+    private boolean touchTokens(Map<String, Long> tokenToId, Map<String, Boolean> result) {
+        List<Long> successIds = new ArrayList<>();
+        List<Long> failedIds = new ArrayList<>();
+
+        for (Map.Entry<String, Boolean> e : result.entrySet()) {
+            Long tid = tokenToId.get(e.getKey());
+            if (tid == null) continue;
+            if (Boolean.TRUE.equals(e.getValue())) successIds.add(tid);
+            else failedIds.add(tid);
+        }
+
+        if (!successIds.isEmpty()) {
+            pushTokenRepository.touchSuccess(successIds, LocalDateTime.now(ZoneId.systemDefault()));
+        }
+        for (Long tid : failedIds) {
+            pushTokenRepository.increaseFailCount(tid);
+        }
+
+        return !successIds.isEmpty();
+    }
+}

--- a/backend/community/src/main/java/com/heyoung/domain/notification/service/PushTokenService.java
+++ b/backend/community/src/main/java/com/heyoung/domain/notification/service/PushTokenService.java
@@ -1,0 +1,10 @@
+package com.heyoung.domain.notification.service;
+
+import com.heyoung.domain.notification.dto.request.PushTokenDtos;
+import com.heyoung.domain.notification.entity.PushToken;
+import com.heyoung.global.enums.NotificationChannel;
+
+public interface PushTokenService {
+    PushToken register(Long userId, PushTokenDtos.RegisterRequest request);
+    PushToken deactivate(Long userId, NotificationChannel channel, String token);
+}

--- a/backend/community/src/main/java/com/heyoung/domain/notification/service/PushTokenServiceImpl.java
+++ b/backend/community/src/main/java/com/heyoung/domain/notification/service/PushTokenServiceImpl.java
@@ -1,0 +1,50 @@
+package com.heyoung.domain.notification.service;
+
+import com.heyoung.domain.notification.dto.request.PushTokenDtos;
+import com.heyoung.domain.notification.entity.PushToken;
+import com.heyoung.domain.notification.repository.PushTokenRepository;
+import com.heyoung.global.enums.NotificationChannel;
+import com.heyoung.global.util.TokenHash;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class PushTokenServiceImpl implements PushTokenService {
+    private final PushTokenRepository pushTokenRepository;
+
+    @Override
+    @Transactional
+    public PushToken register(Long userId, PushTokenDtos.RegisterRequest request) {
+        String hash = TokenHash.sha256Hex(request.token());
+        LocalDateTime now = LocalDateTime.now();
+
+        // channel + token_hash 유니크로 조회
+        var existing = pushTokenRepository.findByChannelAndTokenHash(request.channel(), hash).orElse(null);
+        if (existing != null) {
+            existing.refresh(userId, request.token(), request.appVersion(), request.osVersion(), request.deviceVersion(), now);
+            return existing;
+        }
+
+        // 신규 생성
+        PushToken created = PushToken.create(
+                userId, request.channel(),
+                request.token(), hash,
+                request.appVersion(), request.osVersion(), request.deviceVersion(),
+                now
+        );
+        return pushTokenRepository.save(created);
+    }
+
+    @Transactional
+    public PushToken deactivate(Long userId, NotificationChannel channel, String token) {
+        String hash = TokenHash.sha256Hex(token);
+        var pt = pushTokenRepository.findByUserIdAndChannelAndTokenHash(userId, channel, hash)
+                .orElseThrow(() -> new IllegalArgumentException("token not found"));
+        pt.deactivate(LocalDateTime.now());
+        return pt;
+    }
+}

--- a/backend/community/src/main/java/com/heyoung/domain/recommendation/repository/UserCategoryRepository.java
+++ b/backend/community/src/main/java/com/heyoung/domain/recommendation/repository/UserCategoryRepository.java
@@ -3,8 +3,12 @@ package com.heyoung.domain.recommendation.repository;
 import com.heyoung.domain.recommendation.entity.UserCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserCategoryRepository extends JpaRepository<UserCategory, Long> {
     Optional<UserCategory> findByUserIdAndCategoryId(Long userId, Long categoryId);
+
+    List<UserCategory> findTop5ByUserIdOrderByUseCountDesc(Long userId);
+
 }

--- a/backend/community/src/main/java/com/heyoung/domain/recommendation/repository/UserHourHistRepository.java
+++ b/backend/community/src/main/java/com/heyoung/domain/recommendation/repository/UserHourHistRepository.java
@@ -4,8 +4,13 @@ import com.heyoung.domain.recommendation.entity.UserHourHist;
 import com.heyoung.global.enums.HourBucket;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 public interface UserHourHistRepository extends JpaRepository<UserHourHist, Long> {
     Optional<UserHourHist> findByUserIdAndHourBucket(Long userId, HourBucket hourBucket);
+    List<UserHourHist> findTop5ByUserIdOrderByUseCountDesc(Long userId);
+    List<UserHourHist> findAllByHourBucketIn(Collection<HourBucket> buckets);
+
 }

--- a/backend/community/src/main/java/com/heyoung/domain/university/exception/UserUniversityException.java
+++ b/backend/community/src/main/java/com/heyoung/domain/university/exception/UserUniversityException.java
@@ -1,0 +1,10 @@
+package com.heyoung.domain.university.exception;
+
+import com.heyoung.global.exception.GeneralException;
+import com.heyoung.global.exception.ResponseCode;
+
+public class UserUniversityException extends GeneralException {
+    public UserUniversityException(ResponseCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/backend/community/src/main/java/com/heyoung/domain/university/service/UserUniversityQueryService.java
+++ b/backend/community/src/main/java/com/heyoung/domain/university/service/UserUniversityQueryService.java
@@ -1,0 +1,7 @@
+package com.heyoung.domain.university.service;
+
+import com.heyoung.domain.university.entity.University;
+
+public interface UserUniversityQueryService {
+    University getUniversityByUserId(Long universityId);
+}

--- a/backend/community/src/main/java/com/heyoung/domain/university/service/UserUniversityQueryServiceImpl.java
+++ b/backend/community/src/main/java/com/heyoung/domain/university/service/UserUniversityQueryServiceImpl.java
@@ -1,0 +1,20 @@
+package com.heyoung.domain.university.service;
+
+import com.heyoung.domain.university.entity.University;
+import com.heyoung.domain.university.exception.UserUniversityException;
+import com.heyoung.domain.university.repository.UserUniversityRepository;
+import com.heyoung.global.exception.ResponseCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserUniversityQueryServiceImpl implements UserUniversityQueryService {
+
+    private final UserUniversityRepository userUniversityRepository;
+    @Override
+    public University getUniversityByUserId(Long userId) {
+        return userUniversityRepository.findByUserId(userId)
+                .orElseThrow(() -> new UserUniversityException(ResponseCode.USER_UNIVERSITY_NOT_FOUND)).getUniversity();
+    }
+}

--- a/backend/community/src/main/java/com/heyoung/global/enums/HourBucket.java
+++ b/backend/community/src/main/java/com/heyoung/global/enums/HourBucket.java
@@ -3,6 +3,8 @@ package com.heyoung.global.enums;
 import com.heyoung.domain.recommendation.exception.UserCategoryControllerAdvice;
 import com.heyoung.global.exception.ResponseCode;
 
+import java.time.LocalTime;
+
 public enum HourBucket {
 
     HOUR_00(0), HOUR_01(1), HOUR_02(2), HOUR_03(3), HOUR_04(4), HOUR_05(5),
@@ -24,6 +26,15 @@ public enum HourBucket {
     public static HourBucket of(java.time.Instant instant, java.time.ZoneId zone) {
         int h = instant.atZone(zone).getHour();
         return VALUES[h];
+    }
+
+    public LocalTime startTime() {
+        return java.time.LocalTime.of(this.hour, 0);
+    }
+
+    public static java.time.LocalTime startTimeOr(java.time.LocalTime fallback, HourBucket bucket) {
+        if (bucket != null) return bucket.startTime();
+        return (fallback != null) ? fallback : java.time.LocalTime.NOON;
     }
 
     /** 다음/이전 시간 버킷 */

--- a/backend/community/src/main/java/com/heyoung/global/enums/NotificationChannel.java
+++ b/backend/community/src/main/java/com/heyoung/global/enums/NotificationChannel.java
@@ -1,5 +1,5 @@
 package com.heyoung.global.enums;
 
 public enum NotificationChannel {
-    PUSH, INAPP
+    PUSH, INAPP, EXPO
 }

--- a/backend/community/src/main/java/com/heyoung/global/enums/SendStatus.java
+++ b/backend/community/src/main/java/com/heyoung/global/enums/SendStatus.java
@@ -1,5 +1,5 @@
 package com.heyoung.global.enums;
 
 public enum SendStatus {
-    PENDING, SENT, FAILED
+    SCHEDULED, SENT, FAILED
 }

--- a/backend/community/src/main/java/com/heyoung/global/exception/ResponseCode.java
+++ b/backend/community/src/main/java/com/heyoung/global/exception/ResponseCode.java
@@ -25,8 +25,13 @@ public enum ResponseCode {
     CATEGORY_NOT_FOUND(HttpStatus.BAD_REQUEST, "CATEGORY001", "해당 카테고리 데이터가 존재하지 않습니다."),
 
     // Hour Error
-    HOUR_OUT_OF_RANGE(HttpStatus.BAD_REQUEST, "HOUR001", "시간대는 00 ~ 23 입니다.");
+    HOUR_OUT_OF_RANGE(HttpStatus.BAD_REQUEST, "HOUR001", "시간대는 00 ~ 23 입니다."),
 
+    // UserUniversityError
+    USER_UNIVERSITY_NOT_FOUND(HttpStatus.BAD_REQUEST, "UNIVERSITY001", "사용자의 대학교 데이터가 존재하지 않습니다."),
+
+    // FCM Error
+    FIREBASE_CREDENTIALS_NOT_FOUND(HttpStatus.UNAUTHORIZED, "FIREBASE001", "FIREBASE 접근 권한이 존재하지 않습니다.");
     private final HttpStatus httpStatus;
     private final String code;
     private final String message;

--- a/backend/community/src/main/java/com/heyoung/global/infra/expo/ExpoPushSender.java
+++ b/backend/community/src/main/java/com/heyoung/global/infra/expo/ExpoPushSender.java
@@ -1,0 +1,131 @@
+package com.heyoung.global.infra.expo;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.heyoung.domain.notification.entity.Notification;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ExpoPushSender {
+
+    private static final String EXPO_ENDPOINT = "https://exp.host/--/api/v2/push/send";
+    private static final int CHUNK_SIZE = 90; // Expo 가이드: 100 이하 권장 (여유있게 90)
+
+    private final ObjectMapper om = new ObjectMapper();
+
+    @Value("${expo.push.access-token:}")
+    private String expoAccessToken;
+
+    public Map<String, Boolean> sendMulticast(Notification n, List<String> expoTokens) throws Exception {
+        Map<String, Boolean> result = new LinkedHashMap<>();
+        if (expoTokens == null || expoTokens.isEmpty()) return result;
+
+        // 유효한 Expo 토큰만 선별
+        List<String> tokens = expoTokens.stream()
+                .filter(ExpoPushSender::looksLikeExpoToken)
+                .distinct()
+                .toList();
+
+        if (tokens.isEmpty()) return result;
+
+        // 90개 단위로 쪼개서 보냄
+        for (int i = 0; i < tokens.size(); i += CHUNK_SIZE) {
+            List<String> chunk = tokens.subList(i, Math.min(tokens.size(), i + CHUNK_SIZE));
+            Map<String, Boolean> chunkResult = sendChunk(n, chunk);
+            result.putAll(chunkResult);
+        }
+        return result;
+    }
+
+    private Map<String, Boolean> sendChunk(Notification n, List<String> tokens) throws Exception {
+        // 메시지 배열 만들기
+        List<Map<String, Object>> messages = new ArrayList<>(tokens.size());
+        for (String t : tokens) {
+            Map<String, Object> msg = new LinkedHashMap<>();
+            msg.put("to", t);
+            msg.put("title", n.getTitle());
+            msg.put("body", n.getContent());
+            msg.put("sound", "default");
+            msg.put("priority", "high");
+            // 앱에서 클릭 시 열 페이지/딥링크가 있으면 data로
+            msg.put("data", Map.of(
+                    "clickUrl", n.getClickUrl(),
+                    "notificationId", n.getId()
+            ));
+            // 필요하면 badge, ttl, channelId 등 추가 가능
+            messages.add(msg);
+        }
+
+        String json = om.writeValueAsString(messages);
+
+        HttpRequest.Builder rb = HttpRequest.newBuilder()
+                .uri(URI.create(EXPO_ENDPOINT))
+                .timeout(Duration.ofSeconds(10))
+                .header(HttpHeaders.ACCEPT, "application/json")
+                .header(HttpHeaders.CONTENT_TYPE, "application/json; charset=utf-8")
+                .header("Accept-encoding", "gzip, deflate")
+                .POST(HttpRequest.BodyPublishers.ofString(json, StandardCharsets.UTF_8));
+
+        if (expoAccessToken != null && !expoAccessToken.isBlank()) {
+            rb.header(HttpHeaders.AUTHORIZATION, "Bearer " + expoAccessToken.trim());
+        }
+
+        HttpClient client = HttpClient.newHttpClient();
+        HttpResponse<String> res = client.send(rb.build(), HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+
+        if (res.statusCode() / 100 != 2) {
+            log.warn("Expo HTTP error status={}, body={}", res.statusCode(), res.body());
+            // 전체 실패로 간주
+            return tokens.stream().collect(Collectors.toMap(t -> t, t -> false, (a, b) -> a, LinkedHashMap::new));
+        }
+
+        // {"data":[{"status":"ok","id":"..."} , {"status":"error","message":"...","details":{"error":"DeviceNotRegistered"}}]}
+        Map<String, Object> body = om.readValue(res.body(), new TypeReference<>() {});
+        Object data = body.get("data");
+        if (!(data instanceof List<?> list)) {
+            log.warn("Expo response has no data array: {}", res.body());
+            return tokens.stream().collect(Collectors.toMap(t -> t, t -> false, (a, b) -> a, LinkedHashMap::new));
+        }
+
+        Map<String, Boolean> tokenResult = new LinkedHashMap<>();
+        for (int i = 0; i < list.size(); i++) {
+            Object elem = list.get(i);
+            String token = tokens.get(i); // 요청 순서 == 응답 순서
+            boolean ok = false;
+
+            if (elem instanceof Map<?,?> m) {
+                String status = String.valueOf(m.get("status"));
+                if ("ok".equalsIgnoreCase(status)) {
+                    ok = true;
+                } else {
+                    // 상세 로그
+                    Object message = m.get("message");
+                    Object details = m.get("details");
+                    String err = (details instanceof Map<?,?> dm) ? String.valueOf(dm.get("error")) : null;
+                    log.warn("Expo FAIL token={} status={} err={} msg={}", token, status, err, message);
+                }
+            }
+            tokenResult.put(token, ok);
+        }
+        return tokenResult;
+    }
+
+    private static boolean looksLikeExpoToken(String token) {
+        return token != null && token.startsWith("ExponentPushToken[") && token.endsWith("]");
+    }
+}

--- a/backend/community/src/main/java/com/heyoung/global/infra/fcm/FcmSender.java
+++ b/backend/community/src/main/java/com/heyoung/global/infra/fcm/FcmSender.java
@@ -1,0 +1,108 @@
+package com.heyoung.global.infra.fcm;
+
+import com.google.firebase.messaging.*;
+import com.heyoung.domain.notification.entity.Notification;
+import com.heyoung.global.exception.BaseResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+@Slf4j
+public class FcmSender {
+    private final FirebaseMessaging firebase;
+
+    public FcmSender(FirebaseMessaging firebase) {
+        this.firebase = firebase;
+    }
+
+    // 여러 토큰으로 멀티캐스트 전송
+    public Map<String, Boolean> sendMulticast(Notification n, List<String> tokens) throws Exception {
+        Map<String, String> data = new HashMap<>();
+        data.put("clickUrl", safe(n.getClickUrl()));
+        data.put("type", n.getType().name());
+        if(n.getPartnership() != null) data.put("partnershipId", String.valueOf(n.getPartnership().getId()));
+
+        com.google.firebase.messaging.Notification notif =
+                com.google.firebase.messaging.Notification.builder()
+                        .setTitle(safe(n.getTitle()))
+                        .setBody(safe(n.getContent()))
+                        .setImage(safe(n.getImagePath()))
+                        .build();
+
+        MulticastMessage msg = MulticastMessage.builder()
+                .setNotification(notif)
+                .putAllData(data)
+                .addAllTokens(tokens)
+                .build();
+
+        BatchResponse response = null;
+        try {
+            response = firebase.sendEachForMulticast(msg, false);
+            log.info("FCM batch sent: success={}, failure={}",
+                    response.getSuccessCount(), response.getFailureCount());
+        } catch (com.google.firebase.messaging.FirebaseMessagingException e) {
+            // 전체 실패: 재시도/알림/모니터링 등
+            log.error("FCM request failed. code={}, messagingCode={}, msg={}",
+                    e.getErrorCode(), e.getMessagingErrorCode(), e.getMessage(), e);
+        }
+
+        // ★ 개별 토큰 처리
+        var results = response.getResponses();
+        for (int i = 0; i < results.size(); i++) {
+            SendResponse r = results.get(i);
+            String token = tokens.get(i); // MulticastMessage에 넣은 순서와 동일
+
+            if (r.isSuccessful()) {
+                String messageId = r.getMessageId();
+                log.info("FCM OK token={}, messageId={}", token, messageId);
+
+                continue;
+            }
+
+            Exception ex = r.getException();
+            if (ex instanceof FirebaseMessagingException fme) {
+                var mcode = fme.getMessagingErrorCode();  // INVALID_ARGUMENT, UNREGISTERED, ...
+                var http  = fme.getErrorCode();           // HTTP 상태류
+                log.warn("FCM FAIL token={} mcode={} http={} detail={}",
+                        token, mcode, http, fme.getMessage());
+
+                // 실패 유형별 후처리 예시
+                if (mcode == MessagingErrorCode.UNREGISTERED
+                        || mcode == MessagingErrorCode.INVALID_ARGUMENT
+                        || mcode == MessagingErrorCode.SENDER_ID_MISMATCH) {
+                    // 영구 실패: 토큰 비활성화
+                    // pushTokenRepository.markInactiveByToken(token, InvalidType.UNREGISTERED);
+                } else if (mcode == MessagingErrorCode.QUOTA_EXCEEDED
+                        || mcode == MessagingErrorCode.UNAVAILABLE
+                        || mcode == MessagingErrorCode.INTERNAL) {
+                    // 일시 실패: 재시도 큐로
+                    // retryQueue.offer(token);
+                } else {
+                    // 그 외: 실패 카운트 증가 등
+                    // pushTokenRepository.increaseFailCount(token);
+                }
+            } else {
+                log.error("FCM FAIL token={} exType={} msg={}",
+                        token, ex.getClass().getSimpleName(), ex.getMessage(), ex);
+                // 기타 예외도 실패 카운트 증가 등
+                // pushTokenRepository.increaseFailCount(token);
+            }
+        }
+
+        Map<String, Boolean> result = new HashMap<>();
+        for(int i = 0; i<tokens.size(); i++) {
+            SendResponse r = response.getResponses().get(i);
+            result.put(tokens.get(i), r.isSuccessful());
+        }
+
+        return result;
+    }
+
+    private static String safe(String s) {
+        return (s == null) ? "" : s;
+    }
+}

--- a/backend/community/src/main/java/com/heyoung/global/infra/fcm/FirebaseConfig.java
+++ b/backend/community/src/main/java/com/heyoung/global/infra/fcm/FirebaseConfig.java
@@ -1,0 +1,28 @@
+package com.heyoung.global.infra.fcm;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.messaging.FirebaseMessaging;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.io.FileInputStream;
+
+@Configuration
+public class FirebaseConfig {
+
+    @Bean
+    public FirebaseMessaging firebaseMessaging() throws Exception {
+
+        FileInputStream serviceAccount =
+                new FileInputStream("community/src/main/resources/heyoung-firebase-adminsdk.json");
+
+        FirebaseOptions options = new FirebaseOptions.Builder()
+                .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                .build();
+
+        if(FirebaseApp.getApps().isEmpty()) FirebaseApp.initializeApp(options);
+        return FirebaseMessaging.getInstance();
+    }
+}

--- a/backend/community/src/main/java/com/heyoung/global/infra/fcm/FirebaseConfig.java
+++ b/backend/community/src/main/java/com/heyoung/global/infra/fcm/FirebaseConfig.java
@@ -1,28 +1,63 @@
 package com.heyoung.global.infra.fcm;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import com.google.firebase.messaging.FirebaseMessaging;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import java.io.FileInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
 
 @Configuration
+@RequiredArgsConstructor
+@Slf4j
 public class FirebaseConfig {
+
+    private final FirebaseCredentials credentials;
+    private final ObjectMapper objectMapper;
 
     @Bean
     public FirebaseMessaging firebaseMessaging() throws Exception {
 
-        FileInputStream serviceAccount =
-                new FileInputStream("community/src/main/resources/heyoung-firebase-adminsdk.json");
+        Map<String, Object> credentialsMap = new HashMap<>();
+        credentialsMap.put("type", credentials.getType());
+        credentialsMap.put("project_id", credentials.getProjectId());
+        credentialsMap.put("private_key_id", credentials.getPrivateKeyId());
+        credentialsMap.put("private_key", credentials.getPrivateKey());
+        credentialsMap.put("client_email", credentials.getClientEmail());
+        credentialsMap.put("client_id", credentials.getClientId());
+        credentialsMap.put("auth_uri", credentials.getAuthUri());
+        credentialsMap.put("token_uri", credentials.getTokenUri());
+        credentialsMap.put("auth_provider_x509_cert_url", credentials.getAuthProviderX509CertUrl());
+        credentialsMap.put("client_x509_cert_url", credentials.getClientX509CertUrl());
+        credentialsMap.put("universe_domain", credentials.getUniverseDomain());
 
-        FirebaseOptions options = new FirebaseOptions.Builder()
-                .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+        String credentialsJson = objectMapper.writeValueAsString(credentialsMap);
+
+        // InputStream을 직접 사용 (FileInputStream 불필요)
+        InputStream credentialsStream = new ByteArrayInputStream(
+                credentialsJson.getBytes(StandardCharsets.UTF_8)
+        );
+
+        FirebaseOptions options = FirebaseOptions.builder()
+                .setCredentials(GoogleCredentials.fromStream(credentialsStream))
                 .build();
 
-        if(FirebaseApp.getApps().isEmpty()) FirebaseApp.initializeApp(options);
+        if (FirebaseApp.getApps().isEmpty()) {
+            FirebaseApp.initializeApp(options);
+            log.info("Firebase App initialized successfully");
+        }
+
         return FirebaseMessaging.getInstance();
     }
+
+
 }

--- a/backend/community/src/main/java/com/heyoung/global/infra/fcm/FirebaseCredentials.java
+++ b/backend/community/src/main/java/com/heyoung/global/infra/fcm/FirebaseCredentials.java
@@ -1,0 +1,22 @@
+package com.heyoung.global.infra.fcm;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "firebase.credentials")
+@Data
+public class FirebaseCredentials {
+    private String type;
+    private String projectId;
+    private String privateKeyId;
+    private String privateKey;
+    private String clientEmail;
+    private String clientId;
+    private String authUri;
+    private String tokenUri;
+    private String authProviderX509CertUrl;
+    private String clientX509CertUrl;
+    private String universeDomain;
+}

--- a/backend/community/src/main/java/com/heyoung/global/infra/fcm/exception/FcmException.java
+++ b/backend/community/src/main/java/com/heyoung/global/infra/fcm/exception/FcmException.java
@@ -1,0 +1,10 @@
+package com.heyoung.global.infra.fcm.exception;
+
+import com.heyoung.global.exception.GeneralException;
+import com.heyoung.global.exception.ResponseCode;
+
+public class FcmException extends GeneralException {
+    public FcmException(ResponseCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/backend/community/src/main/java/com/heyoung/global/util/TokenHash.java
+++ b/backend/community/src/main/java/com/heyoung/global/util/TokenHash.java
@@ -1,0 +1,23 @@
+package com.heyoung.global.util;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+
+public final class TokenHash {
+    private TokenHash() {}
+
+    public static String sha256Hex(String raw) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            byte[] dig = md.digest(raw.getBytes(StandardCharsets.UTF_8));
+            StringBuilder sb = new StringBuilder(dig.length * 2);
+            for (byte b : dig) {
+                sb.append(Character.forDigit((b >>> 4) & 0xF, 16));
+                sb.append(Character.forDigit((b       ) & 0xF, 16));
+            }
+            return sb.toString(); // length 64, lower-case hex
+        } catch (Exception e) {
+            throw new IllegalStateException("SHA-256 unavailable", e);
+        }
+    }
+}

--- a/backend/community/src/main/resources/data.sql
+++ b/backend/community/src/main/resources/data.sql
@@ -1,6 +1,49 @@
 CREATE EXTENSION IF NOT EXISTS postgis;
 CREATE EXTENSION IF NOT EXISTS postgis_topology;
 
+SET TIME ZONE 'Asia/Seoul';
+
+-- 이미 같은 (channel, token_hash)가 있을 수 있으니, 중복은 무시
+-- 제약 이름을 그대로 사용: uq_push_token_channel_hash
+INSERT INTO push_token
+(user_id, channel, token, token_hash, active, fail_count, invalid_type,
+ last_seen_at, last_sent_at, app_version, os_version, device_version,
+ created_date, updated_date)
+VALUES
+-- 활성 PUSH 토큰: 최근 본 / 최근 보낸 시각 예시
+(1001, 'EXPO', 'ExponentPushToken[Xa-K20A8h9SQ12HRvQqAoo]', 'ExponentPushToken[Xa-K20A8h9SQ12HRvQqAoo]',
+ true, 0, NULL,
+ now() - interval '10 minutes', now() - interval '1 day', '1.2.3', 'iOS17.4', 'iPhone12,1',
+ now(), now()),
+(1002, 'PUSH', 'fcm_1002_A', '2222222222222222222222222222222222222222222222222222222222222222',
+ true, 0, NULL,
+ now() - interval '45 minutes', now() - interval '2 days', '1.1.9', 'Android14', 'SM-S911N',
+ now(), now()),
+(1003, 'PUSH', 'fcm_1003_A', '3333333333333333333333333333333333333333333333333333333333333333',
+ true, 0, NULL,
+ now() - interval '2 hours', now() - interval '3 days', '1.0.0', 'iOS17.0', 'iPhone13,4',
+ now(), now()),
+
+-- 비활성/실패 누적 토큰 예시
+(1001, 'PUSH', 'fcm_1001_OLD', '4444444444444444444444444444444444444444444444444444444444444444',
+ false, 3, NULL,
+ now() - interval '30 days', now() - interval '40 days', '0.9.0', 'iOS16.7', 'iPhone10,4',
+ now(), now()),
+
+-- INAPP 채널 토큰(있다면): 채널이 다르면 같은 해시도 허용되지만 여기선 해시도 다르게 둠
+(1004, 'INAPP', 'inapp_1004_A', '5555555555555555555555555555555555555555555555555555555555555555',
+ true, 0, NULL,
+ now() - interval '5 minutes', NULL, '2.0.1', 'Android13', 'Pixel6',
+ now(), now()),
+
+-- 또 다른 활성 PUSH 토큰
+(1005, 'PUSH', 'fcm_1005_A', '6666666666666666666666666666666666666666666666666666666666666666',
+ true, 0, NULL,
+ now() - interval '3 minutes', now() - interval '6 hours', '1.3.0', 'Android14', 'SM-S921N',
+ now(), now())
+
+ON CONFLICT ON CONSTRAINT uq_push_token_channel_hash DO NOTHING;
+
 -- university 더미 데이터
 INSERT INTO university (
     id, name, type, campus_name, address, location, postal_code, main_phone,
@@ -68,6 +111,19 @@ VALUES
     'PUBLIC', NOW(), NOW()
 )
 ON CONFLICT (id) DO NOTHING;
+
+-- user_university 더미 매핑 (user_id → university_id)
+-- university_id는 실제 존재하는 대학교 id로 바꿔서 쓰면 됨
+INSERT INTO user_university (user_id, university_id, created_date, updated_date)
+VALUES
+    (1001, 1, NOW(), NOW()),
+    (1002, 1, NOW(), NOW()),
+    (1003, 2, NOW(), NOW()),
+    (1004, 3, NOW(), NOW()),
+    (1005, 4, NOW(), NOW()),
+    (1006, 5, NOW(), NOW()),
+    (1007, 6, NOW(), NOW());
+
 
 --Category 더미 데이터
 INSERT INTO category (
@@ -193,3 +249,25 @@ ON CONFLICT (id) DO NOTHING;
 INSERT INTO user_university (id, user_id, university_id, created_date, updated_date)
 VALUES (1, 1, 1, NOW(), NOW())
 ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO notification
+(user_id, title, content, type, channel, click_url, image_path,
+ send_status, scheduled_at, partnership_id, created_date, updated_date)
+VALUES
+    (
+        1001,                                        -- << 테스트할 사용자 ID
+        '[테스트] 곧 발송 예정',                       -- title
+        '곧 발송되는지 점검하는 더미 메시지입니다.',     -- content
+        'PAYMENT_BASED',                              -- NotificationType (너희 enum 값으로 맞춰)
+        'EXPO',                                       -- NotificationChannel (INAPP/PUSH 중 실제 발송 로직이 보는 값)
+        'https://example.com',                        -- click_url
+        'https://picsum.photos/200',                  -- image_path
+        'SCHEDULED',                                  -- SendStatus
+        NOW() + INTERVAL '10 seconds',                -- 30초 뒤 발송
+        (SELECT p.id
+         FROM partnership p
+         WHERE p.status = 'ACTIVE'
+         ORDER BY p.id DESC
+         LIMIT 1),                                   -- 임의의 활성 제휴 하나
+        NOW(), NOW()
+    );


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[feat]: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #28 

## ✨ PR 세부 내용

- 사용자별 알림을 예약하기 위해 조용한 시간대에 Batch 를 돌려서 notification 에 저장하여 예약하는 방식으로 구현
- 스케줄러가 돌면서 보내야 하는 알림을 보낸다.
- FCM 이 IOS 에서는 배포해야 동작하는 문제가 발생하여 EXPO 타입의 알림 전송도 구현
- 프론트와 알림 전송 로컬 테스트 완료했습니다.
