### PR TITLE
[FEAT] 계좌 거래 내역 전체 조회 

### DIFF
--- a/backend/core-bank/src/main/java/com/heyoung/domain/payment/controller/TransactionController.java
+++ b/backend/core-bank/src/main/java/com/heyoung/domain/payment/controller/TransactionController.java
@@ -1,8 +1,6 @@
 package com.heyoung.domain.payment.controller;
 
-import com.heyoung.domain.payment.dto.QrTokenDto;
-import com.heyoung.domain.payment.dto.TransactionRequestDto;
-import com.heyoung.domain.payment.dto.TransactionResponseDto;
+import com.heyoung.domain.payment.dto.*;
 import com.heyoung.domain.payment.service.TransactionService;
 import com.heyoung.global.config.MemberId;
 import com.heyoung.global.exception.BaseResponse;
@@ -11,6 +9,8 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Tag(name="거래 및 결제 API", description = "QR 데이터 생성 및 결제 실행을 담당합니다.")
 @RestController
@@ -32,5 +32,16 @@ public class TransactionController {
         // 가맹점으로부터 결제 요청을 받아 처리
         TransactionResponseDto response = transactionService.executeTransaction(requestDto);
         return BaseResponse.onSuccess(response, ResponseCode.OK);
+    }
+
+    @Operation(summary = "계좌 거래 내역 조회 API", description = "지정된 기간의 계좌 거래 내역을 조회하는 API입니다.")
+    @GetMapping("/history")
+    public BaseResponse<List<ExternalBankApiDto.TransactionHistory>> getTransactionHistory(
+            @MemberId Long memberId,
+            @RequestParam("startDate") String startDate,
+            @RequestParam("endDate") String endDate
+    ) {
+        List<ExternalBankApiDto.TransactionHistory> history = transactionService.getTransactionHistory(memberId, startDate, endDate);
+        return BaseResponse.onSuccess(history, ResponseCode.OK);
     }
 }

--- a/backend/core-bank/src/main/java/com/heyoung/domain/payment/dto/ExternalBankApiDto.java
+++ b/backend/core-bank/src/main/java/com/heyoung/domain/payment/dto/ExternalBankApiDto.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 /**
  * 외부 은행 API와의 통신을 위한 DTO들을 모아놓은 클래스
@@ -147,5 +148,97 @@ public class ExternalBankApiDto {
 
         @JsonProperty("transactionDate")
         private String transactionDate;
+    }
+
+    // 3. 계좌 거래 내역 조회
+    /**
+     * 거래 내역 조회 요청 DTO
+     */
+    @Getter
+    @AllArgsConstructor
+    public static class InquireTransactionHistoryRequest {
+        @JsonProperty("Header")
+        private Header Header;
+
+        @JsonProperty("accountNo")
+        private String accountNo;
+
+        @JsonProperty("startDate")
+        private String startDate; // YYYYMMDD
+
+        @JsonProperty("endDate")
+        private String endDate; // YYYYMMDD
+
+        @JsonProperty("transactionType")
+        private String transactionType; // A: 전체, M: 입금, D: 출금
+
+        @JsonProperty("orderByType")
+        private String orderByType; // ASC: 오름차순(이전거래), DESC: 내림차순(최근거래)
+    }
+
+    /**
+     * 거래 내역 조회 응답 DTO
+     */
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    public static class InquireTransactionHistoryResponse {
+        @JsonProperty("Header")
+        private Header Header;
+
+        @JsonProperty("REC")
+        private HistoryRec rec;
+    }
+
+    /**
+     * 거래 내역 조회 응답의 REC 필드 내부 객체
+     */
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    public static class HistoryRec {
+        @JsonProperty("totalCount")
+        private String totalCount;
+
+        @JsonProperty("list")
+        private List<TransactionHistory> list;
+    }
+
+    /**
+     * 개별 거래 내역 정보
+     */
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    public static class TransactionHistory {
+        @JsonProperty("transactionUniqueNo")
+        private Long transactionUniqueNo;
+
+        @JsonProperty("transactionDate")
+        private String transactionDate;
+
+        @JsonProperty("transactionTime")
+        private String transactionTime;
+
+        @JsonProperty("transactionType")
+        private String transactionType;
+
+        @JsonProperty("transactionTypeName")
+        private String transactionTypeName;
+
+        @JsonProperty("transactionAccountNo")
+        private String transactionAccountNo;
+
+        @JsonProperty("transactionBalance")
+        private Long transactionBalance;
+
+        @JsonProperty("transactionSummary")
+        private String transactionSummary;
+
+        @JsonProperty("transactionAfterBalance")
+        private Long transactionAfterBalance;
+
+        @JsonProperty("transactionMemo")
+        private String transactionMemo;
     }
 }

--- a/backend/core-bank/src/main/java/com/heyoung/domain/payment/service/ExternalBankApiService.java
+++ b/backend/core-bank/src/main/java/com/heyoung/domain/payment/service/ExternalBankApiService.java
@@ -35,6 +35,9 @@ public class ExternalBankApiService {
     @Value("${external.bank.api.key}")
     private String apiKey;
 
+    @Value("${external.bank.api.url.history}")
+    private String historyUrl;
+
     // API 명세에 맞는 날짜/시간 포맷 정의
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
     private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HHmmss");
@@ -84,6 +87,32 @@ public class ExternalBankApiService {
             }
         } catch (RestClientException e) {
             log.error("External API call failed during withdraw: ", e);
+            throw new ExternalApiCallException(e);
+        }
+    }
+
+    /**
+     * 외부 API를 호출하여 계좌 거래 내역 조회
+     */
+    public ExternalBankApiDto.InquireTransactionHistoryResponse inquireTransactionHistory(Long userId, String accountNo, String startDate, String endDate, String transactionType, String orderByType) {
+        ExternalBankApiDto.Header header = createHeader("inquireTransactionHistoryList", userId);
+        ExternalBankApiDto.InquireTransactionHistoryRequest request = new ExternalBankApiDto.InquireTransactionHistoryRequest(header, accountNo, startDate, endDate, transactionType, orderByType);
+        HttpEntity<ExternalBankApiDto.InquireTransactionHistoryRequest> requestEntity = new HttpEntity<>(request, createHttpHeaders());
+
+        try {
+            ExternalBankApiDto.InquireTransactionHistoryResponse response = restTemplate.postForObject(historyUrl, requestEntity, ExternalBankApiDto.InquireTransactionHistoryResponse.class);
+
+            if (response == null || !response.getHeader().getResponseCode().equals("H0000") || response.getRec() == null) {
+                if (response != null && !response.getHeader().getResponseCode().equals("H0000")) {
+                    log.warn("External API call for history returned non-H0000 code: {}", response.getHeader().getResponseCode());
+                }
+                if (response == null) {
+                    throw new ExternalApiCallException();
+                }
+            }
+            return response;
+        } catch (RestClientException e) {
+            log.error("External API call failed during inquireTransactionHistory: ", e);
             throw new ExternalApiCallException(e);
         }
     }

--- a/backend/core-bank/src/main/java/com/heyoung/domain/payment/service/TransactionService.java
+++ b/backend/core-bank/src/main/java/com/heyoung/domain/payment/service/TransactionService.java
@@ -1,5 +1,6 @@
 package com.heyoung.domain.payment.service;
 
+import com.heyoung.domain.payment.dto.ExternalBankApiDto;
 import com.heyoung.domain.payment.dto.QrDataDto;
 import com.heyoung.domain.payment.dto.QrTokenDto;
 import com.heyoung.domain.payment.dto.TransactionRequestDto;
@@ -24,6 +25,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+
 import com.heyoung.global.exception.InsufficientBalanceException;
 
 @Service
@@ -92,6 +96,34 @@ public class TransactionService {
                 savedTransaction.getTransactionDateTime()
         );
     }
+
+    // 계좌 거래 내역 전체 조회
+    @Transactional(readOnly = true)
+    public List<ExternalBankApiDto.TransactionHistory> getTransactionHistory(Long memberId, String startDate, String endDate) {
+        User user = userRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자"));
+        Account account = accountRepository.findByUser(user)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 계좌"));
+
+        // 외부 API 호출
+        ExternalBankApiDto.InquireTransactionHistoryResponse response = externalBankApiService.inquireTransactionHistory(
+                memberId,
+                account.getAccountNumber(),
+                startDate,
+                endDate,
+                "A",  // "A": 전체 거래 내역
+                "DESC" // "DESC": 최신순
+        );
+
+        if (response.getRec() == null || response.getRec().getList() == null) {
+            return Collections.emptyList();
+        }
+
+        return response.getRec().getList();
+    }
+
+
+
     private Transaction createTransaction(User user, Account account, Category category, TransactionRequestDto dto) {
         return Transaction.builder()
                 .user(user)


### PR DESCRIPTION
## 📌 관련 이슈

- closed: #83 

## ✨ PR 세부 내용
### Dto 추가
- 은행 API의 '계좌 거래 내역 조회' 명세에 따라 InquireTransactionHistoryRequest, InquireTransactionHistoryResponse DTO 및 하위 클래스 추가
### Service 추가 
- getTransactionHistory 메소드에서 컨트롤러와 Open API 서비스 간의 비즈니스 로직 처리 
### Controller 엔드포인트 추가 
- GET /transactions/history 엔드포인트를 추가하여 거래 내역 요청 가능 
